### PR TITLE
Map in vmapp arguments

### DIFF
--- a/bfcrt/src/start.c
+++ b/bfcrt/src/start.c
@@ -46,7 +46,7 @@ _start(struct crt_info *info)
     // place the arguments into some allocated memory, and pass the string
     // information as well as the number of args.
 
-    int ret = main(0, 0);
+    int ret = main(info->argc, info->argv);
 
     for (i = 0; i < info->info_num; i++)
         local_fini(&info->info[i]);

--- a/bfexec/include/process.h
+++ b/bfexec/include/process.h
@@ -35,7 +35,7 @@ class process
 {
 public:
 
-    process(const std::string &filename, processlistid::type procltid);
+    process(int argc, const char **argv, processlistid::type procltid);
     ~process();
 
     gsl::not_null<bfelf_file_t *> load_elf(const std::string &filename);
@@ -51,6 +51,9 @@ private:
     std::string m_filename;
     std::string m_basename;
 
+    std::size_t m_argv_size;
+    std::unique_ptr<char> m_argv;
+
     bfelf_loader_t m_loader;
 
     std::unique_ptr<char> m_stack;
@@ -58,6 +61,9 @@ private:
 
     std::vector<std::unique_ptr<char>> m_segments;
     std::vector<std::unique_ptr<bfelf_file_t>> m_elfs;
+
+    void argv_size(int argc, const char **argv, std::size_t limit);
+    void init_argv(int argc, const char **argv, uintptr_t vm_virt, std::size_t limit);
 
 public:
 

--- a/bfexec/src/set_affinity.c
+++ b/bfexec/src/set_affinity.c
@@ -25,9 +25,9 @@
 #include <windows.h>
 
 int
-set_affinity(void)
+set_affinity(long int core)
 {
-    if (SetProcessAffinityMask(GetCurrentProcess(), 1) == 0)
+    if (SetProcessAffinityMask(GetCurrentProcess(), 1ull << core) == 0)
         return -1;
 
     return 0;
@@ -37,14 +37,17 @@ set_affinity(void)
 
 #define _GNU_SOURCE
 #include <sched.h>
+#include <sys/sysinfo.h>
 
 int
-set_affinity(void)
+set_affinity(long int core)
 {
     cpu_set_t  mask;
+    struct sysinfo info;
+    sysinfo(&info);
 
     CPU_ZERO(&mask);
-    CPU_SET(0, &mask);
+    CPU_SET(core, &mask);
 
     if (sched_setaffinity(0, sizeof(mask), &mask) != 0)
         return -1;

--- a/bfexec/src/vcpu.cpp
+++ b/bfexec/src/vcpu.cpp
@@ -29,6 +29,7 @@ vcpu::vcpu(processlistid::type procltid) :
     m_id(vmcall__create_foreign_vcpu(procltid)),
     m_procltid(procltid)
 {
+    std::cout << "called vmcall__create_foreign_vcpu\n";
     if (m_id == vcpuid::invalid)
         throw std::runtime_error("vmcall__create_foreign_vcpu failed");
 }
@@ -37,4 +38,5 @@ vcpu::~vcpu()
 {
     if (!vmcall__delete_vcpu(m_id))
         bfwarning << "vmcall__delete_vcpu failed\n";
+    std::cout << "called vmcall__delete_vcpu\n";
 }

--- a/include/crt_info.h
+++ b/include/crt_info.h
@@ -34,7 +34,7 @@ extern "C" {
 struct crt_info
 {
     int argc;
-    char *argv;
+    char **argv;
 
     uintptr_t program_break;
 

--- a/tests/basic_c/src/main.c
+++ b/tests/basic_c/src/main.c
@@ -25,9 +25,11 @@
 int
 main(int argc, const char *argv[])
 {
-    (void) argc;
-    (void) argv;
-
     printf("hello world\n");
+
+    for (int i = 0; i < argc; i++) {
+        printf("    argv[%d] = %s\n", i, argv[i]);
+    }
+
     return 0;
 }


### PR DESCRIPTION
This patch modifies bfexec to accept a core number, followed
by the vmapp, followed by the vmapp's arguments.

The core number specifies the affinity of the resulting vmcalls.

A 4k page is allocated and initialized with the vmapp's arguments
and is then mapped into the vmapp's address space.